### PR TITLE
angler: disable unneeded init services

### DIFF
--- a/init.angler.rc
+++ b/init.angler.rc
@@ -467,12 +467,6 @@ service msm_irqbalance /system/bin/msm_irqbalance -f /system/etc/msm_irqbalance.
     group root
     writepid /dev/cpuset/system-background/tasks
 
-#start atfwd as daemon
-service atfwd /system/bin/ATFWD-daemon
-    class late_start
-    user system
-    group system radio
-
 service ppd /system/bin/mm-pp-daemon
     class late_start
     user system
@@ -481,12 +475,3 @@ service ppd /system/bin/mm-pp-daemon
 
 on property:init.svc.surfaceflinger=stopped
     stop ppd
-
-service diag_test_server /vendor/bin/diag_test_server
-    class core
-    user root
-    disabled
-
-on property:ro.boot.mode=hw-factory
-    start diag_test_server
-


### PR DESCRIPTION
- atfwd can be disabled (no matching atfwd.apk for angler)
- remove diag services

Change-Id: I0c11ac12205b6ce2f846e48972c2e6827569e914
Signed-off-by: Roman Birg <roman@cyngn.com>