### PR TITLE
angler: correct naming of blob makefile in aosp_angler.mk

### DIFF
--- a/aosp_angler.mk
+++ b/aosp_angler.mk
@@ -32,5 +32,5 @@ PRODUCT_MANUFACTURER := Huawei
 PRODUCT_RESTRICT_VENDOR_FILES := false
 
 $(call inherit-product, device/huawei/angler/device.mk)
-$(call inherit-product-if-exists, vendor/huawei/angler/device-vendor.mk)
+$(call inherit-product-if-exists, vendor/huawei/angler/angler-vendor.mk)
 


### PR DESCRIPTION
Change-Id: I2508b105a1e8b1c1218b59cbb8bd40476aa69ac3