### PR TITLE
angler: flag app that is in playstore as presigned

### DIFF
--- a/proprietary-blobs.txt
+++ b/proprietary-blobs.txt
@@ -136,5 +136,5 @@ system/lib/libqomx_core.so
 system/lib/libtinyxml.so
 system/lib/soundfx/libfmas.so
 -system/priv-app/CNEService/CNEService.apk
--system/priv-app/HotwordEnrollment/HotwordEnrollment.apk
+-system/priv-app/HotwordEnrollment/HotwordEnrollment.apk:PRESIGNED
 system/xbin/wlutil


### PR DESCRIPTION
This prevents signature check failure and certificate mismatch error from
the playstore.

Change-Id: I010528b8de606b3a6be265dca50b9d754350ec30