### PR TITLE
Revert "Use multithread decode for boot animation."

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -97,8 +97,6 @@ BOARD_CHARGER_DISABLE_INIT_BLANK := true
 # Enable auto suspend in poweroff charging to save power
 BOARD_CHARGER_ENABLE_SUSPEND := true
 
-TARGET_BOOTANIMATION_MULTITHREAD_DECODE := true
-
 # Enable dex-preoptimization to speed up first boot sequence
 #ifeq ($(HOST_OS),linux)
 #  ifneq ($(TARGET_BUILD_VARIANT),eng)


### PR DESCRIPTION
It's no longer necessary to have this in the device tree.  It was
enabled globally by http://review.cyanogenmod.org/#/c/168501/

This reverts commit db62d1b0e93488d1037aa646704b3e93f0844aa3.

Change-Id: I719f8f82b2b4475e832a42bb08db52e112244459