### PR TITLE
angler: add missing line continuation slash

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -327,7 +327,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # for perfd
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.min_freq_0=384000
+    ro.min_freq_0=384000 \
     ro.min_freq_4=384000
 
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
This adds the perfd property that's missing in the build.prop

Change-Id: I9342ef2c7add9c11bf7e7bd35c87e18f905f19a7